### PR TITLE
[Feat] 커스텀 ChatCacheStore 구현 및 적용

### DIFF
--- a/src/main/java/dev/soon/interviewdefense/chat/controller/ChatController.java
+++ b/src/main/java/dev/soon/interviewdefense/chat/controller/ChatController.java
@@ -33,18 +33,20 @@ public class ChatController {
     @PostMapping("/create")
     public String createChatRoom(@AuthenticationPrincipal SecurityUser securityUser,
                                  @ModelAttribute("chat") ChatRoomReqDto dto) {
-        Long chatRoomId = chatServiceV2.createChatRoom(securityUser, dto);
+        String email = securityUser.getUsername();
+        Long chatRoomId = chatServiceV2.createChatRoom(email, dto);
         return "redirect:/chat/" + chatRoomId;
     }
 
     @GetMapping("/{chatRoomId}")
     public String getChatRoom(@AuthenticationPrincipal SecurityUser securityUser,
-                              @PathVariable Long chatRoomId, Model model) {
-        Chat chatRoom = chatServiceV2.getChatRoom(securityUser, chatRoomId);
+                              @PathVariable Long chatRoomId,
+                              Model model) {
+        String email = securityUser.getUsername();
+        Chat chatRoom = chatServiceV2.getChatRoom(email, chatRoomId);
         List<ChatMessage> chatMessagesInChatRoom = chatServiceV2.getChatRoomMessages(chatRoom);
         model.addAttribute("chatMessages", chatMessagesInChatRoom);
 
-        String email = securityUser.getUsername();
         User loginUser = userService.getUserByEmail(email);
         model.addAttribute("user", loginUser);
         return "chatRoom";
@@ -53,7 +55,8 @@ public class ChatController {
     @PostMapping("/{chatRoomId}/delete")
     public String deleteChat(@PathVariable Long chatRoomId,
                              @AuthenticationPrincipal SecurityUser securityUser) {
-        chatServiceV2.deleteChat(chatRoomId, securityUser);
+        String email = securityUser.getUsername();
+        chatServiceV2.deleteChat(chatRoomId, email);
         return "redirect:/";
     }
 }

--- a/src/main/java/dev/soon/interviewdefense/chat/respository/ChatCacheStore.java
+++ b/src/main/java/dev/soon/interviewdefense/chat/respository/ChatCacheStore.java
@@ -1,0 +1,55 @@
+package dev.soon.interviewdefense.chat.respository;
+
+import dev.soon.interviewdefense.chat.domain.Chat;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Component
+public class ChatCacheStore {
+
+    private final Map<Long, Chat> chatMap;
+    private final Map<String, Chat> webSocketSessionUserChatMap;
+
+    public ChatCacheStore() {
+        this.chatMap = new ConcurrentHashMap<>();
+        this.webSocketSessionUserChatMap = new ConcurrentHashMap<>();
+    }
+
+    public void cacheChat(Chat chat) {
+        chatMap.put(chat.getId(), chat);
+    }
+
+    public void cacheEmailAndChat(String email, Chat chat) {
+        this.webSocketSessionUserChatMap.put(email, chat);
+    }
+
+    public <T> Chat getChatByCacheKey(T key) {
+        if(key instanceof Long) {
+            log.info("cache hit={}", key);
+            return chatMap.get(key);
+        }
+        if(key instanceof String) {
+            log.info("cache hit={}", key);
+            return webSocketSessionUserChatMap.get(key);
+        }
+        throw new IllegalArgumentException("invalid key!!");
+    }
+
+    public boolean existsCacheByEmail(Long chatId) {
+        return this.chatMap.containsKey(chatId);
+    }
+
+    public <T> void removeCache(T key) {
+        if(key instanceof Long) {
+            this.chatMap.remove(key);
+            return;
+        }
+        if(key instanceof String) {
+            this.webSocketSessionUserChatMap.remove(key);
+        }
+    }
+}

--- a/src/main/java/dev/soon/interviewdefense/chat/service/ChatService.java
+++ b/src/main/java/dev/soon/interviewdefense/chat/service/ChatService.java
@@ -4,19 +4,18 @@ import com.theokanning.openai.completion.chat.ChatCompletionChunk;
 import dev.soon.interviewdefense.chat.controller.dto.ChatRoomReqDto;
 import dev.soon.interviewdefense.chat.domain.Chat;
 import dev.soon.interviewdefense.chat.domain.ChatMessage;
-import dev.soon.interviewdefense.security.SecurityUser;
 import io.reactivex.Flowable;
 
 import java.util.List;
 
 public interface ChatService {
-    Chat getChatRoom(SecurityUser securityUser, Long chatRoomId);
+    Chat getChatRoom(String email, Long chatRoomId);
 
-    Long createChatRoom(SecurityUser securityUser, ChatRoomReqDto dto);
+    Long createChatRoom(String email, ChatRoomReqDto dto);
 
     Flowable<ChatCompletionChunk> generateStreamResponse(Chat chat, String question);
 
-    void deleteChat(Long chatRoomId, SecurityUser securityUser);
+    void deleteChat(Long chatRoomId, String email);
 
     List<ChatMessage> getChatRoomMessages(Chat chatRoom);
 }

--- a/src/main/java/dev/soon/interviewdefense/chat/service/ChatServiceV2.java
+++ b/src/main/java/dev/soon/interviewdefense/chat/service/ChatServiceV2.java
@@ -6,11 +6,11 @@ import com.theokanning.openai.service.OpenAiService;
 import dev.soon.interviewdefense.chat.controller.dto.ChatRoomReqDto;
 import dev.soon.interviewdefense.chat.domain.Chat;
 import dev.soon.interviewdefense.chat.domain.ChatMessage;
+import dev.soon.interviewdefense.chat.respository.ChatCacheStore;
 import dev.soon.interviewdefense.chat.respository.ChatMessageRepository;
 import dev.soon.interviewdefense.chat.respository.ChatRepository;
 import dev.soon.interviewdefense.exception.ApiException;
 import dev.soon.interviewdefense.exception.CustomErrorCode;
-import dev.soon.interviewdefense.security.SecurityUser;
 import dev.soon.interviewdefense.user.domain.User;
 import dev.soon.interviewdefense.user.repository.UserRepository;
 import io.reactivex.Flowable;
@@ -29,26 +29,41 @@ import static dev.soon.interviewdefense.chat.util.PromptGenerator.*;
 public class ChatServiceV2 implements ChatService {
 
     private final ChatRepository chatRepository;
+
     private final UserRepository userRepository;
 
     private final OpenAiService openAiService;
+
     private final ChatMessageRepository chatMessageRepository;
+
+    private final ChatCacheStore chatCacheStore;
 
     @Override
     @Transactional
-    public Long createChatRoom(SecurityUser securityUser, ChatRoomReqDto dto) {
-        User user = userRepository.findUserByEmail(securityUser.getUsername())
+    public Long createChatRoom(String email, ChatRoomReqDto dto) {
+        User user = userRepository.findUserByEmail(email)
                 .orElseThrow(() -> new ApiException(CustomErrorCode.NOT_EXISTS_USER_IN_DB));
+
         Chat chat = new Chat(dto, user);
         chatRepository.save(chat);
-        return chat.getId();
+
+        Long chatId = chat.getId();
+        chatCacheStore.cacheChat(chat);
+        return chatId;
     }
 
     @Override
     @Transactional(readOnly = true)
-    public Chat getChatRoom(SecurityUser securityUser, Long chatRoomId) {
-        return chatRepository.findById(chatRoomId)
-                .orElseThrow(() -> new ApiException(CustomErrorCode.NOT_EXISTS_CHATROOM_IN_DB));
+    public Chat getChatRoom(String email, Long chatId) {
+        if(chatCacheStore.existsCacheByEmail(chatId)) {
+            return chatCacheStore.getChatByCacheKey(chatId);
+        }
+        else {
+            Chat chat = chatRepository.findById(chatId)
+                    .orElseThrow(() -> new ApiException(CustomErrorCode.NOT_EXISTS_CHATROOM_IN_DB));
+            chatCacheStore.cacheChat(chat);
+            return chat;
+        }
     }
 
     @Override
@@ -75,18 +90,21 @@ public class ChatServiceV2 implements ChatService {
                 .model("gpt-3.5-turbo")
                 .messages(List.of(new com.theokanning.openai.completion.chat.ChatMessage("system", rolePrompt),
                         new com.theokanning.openai.completion.chat.ChatMessage("user", userPrompt)))
-                .maxTokens(1000)
+                .maxTokens(100)
                 .stream(true)
                 .build();
     }
 
     @Override
     @Transactional
-    public void deleteChat(Long chatRoomId, SecurityUser securityUser) {
-        User user = userRepository.findUserByEmail(securityUser.getUsername())
+    public void deleteChat(Long chatId, String email) {
+        User user = userRepository.findUserByEmail(email)
                 .orElseThrow(() -> new ApiException(CustomErrorCode.NOT_EXISTS_USER_IN_DB));
-        Chat chat = chatRepository.findChatByIdAndUser(chatRoomId, user)
+
+        Chat chat = chatRepository.findChatByIdAndUser(chatId, user)
                 .orElseThrow(() -> new ApiException(CustomErrorCode.NOT_MATCHES_CHAT_ID_AND_USER));
+
         chatRepository.delete(chat);
+        chatCacheStore.removeCache(chatId);
     }
 }

--- a/src/main/java/dev/soon/interviewdefense/chat/service/ChatServiceV2.java
+++ b/src/main/java/dev/soon/interviewdefense/chat/service/ChatServiceV2.java
@@ -29,13 +29,9 @@ import static dev.soon.interviewdefense.chat.util.PromptGenerator.*;
 public class ChatServiceV2 implements ChatService {
 
     private final ChatRepository chatRepository;
-
     private final UserRepository userRepository;
-
     private final OpenAiService openAiService;
-
     private final ChatMessageRepository chatMessageRepository;
-
     private final ChatCacheStore chatCacheStore;
 
     @Override

--- a/src/main/java/dev/soon/interviewdefense/user/domain/User.java
+++ b/src/main/java/dev/soon/interviewdefense/user/domain/User.java
@@ -40,7 +40,7 @@ public class User {
     private final List<UserLanguage> userLanguages = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
-    private final List<UserTech> userTeches = new ArrayList<>();
+    private final List<UserTech> userTechs = new ArrayList<>();
 
     public User(String email, String nickname, String oauth2Provider, String imageUrl) {
         this.email = email;
@@ -62,6 +62,6 @@ public class User {
     }
 
     public void addMyTech(MyTechReqDto dto) {
-        this.userTeches.add(new UserTech(this, dto.name()));
+        this.userTechs.add(new UserTech(this, dto.name()));
     }
 }

--- a/src/main/java/dev/soon/interviewdefense/user/service/UserService.java
+++ b/src/main/java/dev/soon/interviewdefense/user/service/UserService.java
@@ -14,9 +14,9 @@ public interface UserService {
 
     User getUserByEmail(String email);
 
-    List<UserLanguage> getLoginUserLanguages(String email);
+    List<UserLanguage> getUserLanguages(String email);
 
-    List<UserTech> getLoginUserTechs(String email);
+    List<UserTech> getUserTechs(String email);
 
     void addMyLanguageInMyPage(String email, MyLanguageReqDto dto);
 

--- a/src/main/java/dev/soon/interviewdefense/user/service/UserServiceImpl.java
+++ b/src/main/java/dev/soon/interviewdefense/user/service/UserServiceImpl.java
@@ -41,13 +41,13 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public List<UserLanguage> getLoginUserLanguages(String email) {
+    public List<UserLanguage> getUserLanguages(String email) {
         User user = getUserByEmail(email);
         return userLanguageRepository.findUserLanguagesByUser(user);
     }
 
     @Override
-    public List<UserTech> getLoginUserTechs(String email) {
+    public List<UserTech> getUserTechs(String email) {
         User user = getUserByEmail(email);
         return userTechRepository.findUserTechesByUser(user);
     }

--- a/src/main/java/dev/soon/interviewdefense/web/MyPageController.java
+++ b/src/main/java/dev/soon/interviewdefense/web/MyPageController.java
@@ -28,8 +28,8 @@ public class MyPageController {
                          Model model) {
         String email = getEmailBySecurityUser(securityUser);
         User loginUser = userService.getUserByEmail(email);
-        List<UserLanguage> loginUserLanguages = userService.getLoginUserLanguages(email);
-        List<UserTech> loginUserTeches = userService.getLoginUserTechs(email);
+        List<UserLanguage> loginUserLanguages = userService.getUserLanguages(email);
+        List<UserTech> loginUserTeches = userService.getUserTechs(email);
 
         model.addAttribute("user", loginUser);
         model.addAttribute("myLanguages", loginUserLanguages);
@@ -46,12 +46,12 @@ public class MyPageController {
                                Model model) {
         String email = getEmailBySecurityUser(securityUser);
         User loginUser = userService.getUserByEmail(email);
-        List<UserLanguage> loginUserLanguages = userService.getLoginUserLanguages(email);
-        List<UserTech> loginUserTeches = userService.getLoginUserTechs(email);
+        List<UserLanguage> loginUserLanguages = userService.getUserLanguages(email);
+        List<UserTech> loginUserTechs = userService.getUserTechs(email);
 
         model.addAttribute("user", loginUser);
         model.addAttribute("myLanguages", loginUserLanguages);
-        model.addAttribute("myTechs", loginUserTeches);
+        model.addAttribute("myTechs", loginUserTechs);
         return "myPageUpdateForm";
     }
 

--- a/src/main/java/dev/soon/interviewdefense/web/MyPageController.java
+++ b/src/main/java/dev/soon/interviewdefense/web/MyPageController.java
@@ -29,11 +29,11 @@ public class MyPageController {
         String email = getEmailBySecurityUser(securityUser);
         User loginUser = userService.getUserByEmail(email);
         List<UserLanguage> loginUserLanguages = userService.getUserLanguages(email);
-        List<UserTech> loginUserTeches = userService.getUserTechs(email);
+        List<UserTech> loginUserTechs = userService.getUserTechs(email);
 
         model.addAttribute("user", loginUser);
         model.addAttribute("myLanguages", loginUserLanguages);
-        model.addAttribute("myTechs", loginUserTeches);
+        model.addAttribute("myTechs", loginUserTechs);
         return "myPage";
     }
 


### PR DESCRIPTION
- 서비스안에 각각 Map을 만들어서 관리하니 복잡도가 올라가고 프로그래밍시 실수할 가능성이 많아보인다.
- 이 서비스를 컴포넌트화 하자!
- Key 로 채팅방 아이디 혹은 이메일(소켓세션)을 활용한 캐싱서비스를 만들어보자.
- ChatCacheStroe 구현 및 적용
- Chat 객체를 조회할때 Map에 있다면 get 없다면 put을 해줘서 사용도록 구현.
###  Result
- Chat 객체조회 DB콜 개선